### PR TITLE
[security] Fix various vulnerable dependencies (Azure Kusto, JMS)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,8 @@
     <j2objc-annotations.version>1.3</j2objc-annotations.version>
     <lightproto-maven-plugin.version>0.4</lightproto-maven-plugin.version>
     <dependency-check-maven.version>6.1.6</dependency-check-maven.version>
+    <oauth2-oidc-sdk.version>8.36.2</oauth2-oidc-sdk.version>
+    <jakarta.el.version>3.0.4</jakarta.el.version>
   </properties>
   <dependencyManagement>
     <dependencies>
@@ -641,6 +643,11 @@
         <version>${jersey.version}</version>
       </dependency>
       <dependency>
+        <groupId>org.glassfish</groupId>
+        <artifactId>jakarta.el</artifactId>
+        <version>${jakarta.el.version}</version>
+      </dependency>
+      <dependency>
         <groupId>net.java.dev.jna</groupId>
         <artifactId>jna</artifactId>
         <version>${jna.version}</version>
@@ -879,6 +886,11 @@
         <groupId>commons-collections</groupId>
         <artifactId>commons-collections</artifactId>
         <version>${commons.collections.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.nimbusds</groupId>
+        <artifactId>oauth2-oidc-sdk</artifactId>
+        <version>${oauth2-oidc-sdk.version}</version>
       </dependency>
       <!-- test dependencies -->
       <dependency>

--- a/pulsar-connectors/azure-kusto/pom.xml
+++ b/pulsar-connectors/azure-kusto/pom.xml
@@ -30,8 +30,8 @@
       <dependency>
         <groupId>net.minidev</groupId>
         <artifactId>json-smart</artifactId>
-        <!-- up from 2.3. to fix CVE-2021-27568 -->
-        <version>2.3.1</version>
+        <!-- up from 2.4.7 to fix CVE-2021-27568 and CVE-2021-31684 -->
+        <version>2.4.7</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pulsar-connectors/jms/pom.xml
+++ b/pulsar-connectors/jms/pom.xml
@@ -52,6 +52,11 @@
         <artifactId>javax-websocket-server-impl</artifactId>
         <version>${jetty.version}</version>
       </dependency>
+      <dependency>
+        <groupId>io.github.classgraph</groupId>
+        <artifactId>classgraph</artifactId>
+        <version>4.8.116</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
   <dependencies>


### PR DESCRIPTION
* Kusto
  * jakarta.el
  * oauth2-oidc-sdk
  * json-smart
* JMS
   * classgraph

Both the connectors are still vulnerable to Jackson CVE https://nvd.nist.gov/vuln/detail/CVE-2020-36518
JMS still import commons-dbcp 1.4 (from calcite) but there is not a simple upgrade path. If we upgrade calcite to the latest we have commons-dbcp 2.6.0 which is vulnerable. I don't think it would be a good idea to force commons-dbcp 2.9.0 without having tests using calcite
