### PR TITLE
Upgrade Avro to 1.11.4 to address CVE-2024-47561

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
     <kafka-client.version>2.7.2</kafka-client.version>
     <rabbitmq-client.version>5.1.1</rabbitmq-client.version>
     <aws-sdk.version>1.12.262</aws-sdk.version>
-    <avro.version>1.10.2</avro.version>
+    <avro.version>1.11.4</avro.version>
     <joda.version>2.10.5</joda.version>
     <jclouds.version>2.5.0</jclouds.version>
     <guice.version>5.1.0</guice.version>

--- a/src/owasp-dependency-check-suppressions.xml
+++ b/src/owasp-dependency-check-suppressions.xml
@@ -20,14 +20,14 @@
   <!-- add suppressions for known vulnerabilities detected by OWASP Dependency Check -->
   <suppress>
     <notes><![CDATA[
-    file name: avro-1.10.2.jar
+    file name: avro-1.11.4.jar
     ]]></notes>
     <sha1>a65aaa91c1aeceb3dd4859dbb9765d1c2063f5a2</sha1>
     <cve>CVE-2021-43045</cve>
   </suppress>
   <suppress>
     <notes><![CDATA[
-    file name: avro-protobuf-1.10.2.jar
+    file name: avro-protobuf-1.11.4.jar
     ]]></notes>
     <sha1>fbcacef6dd7f2d9864d56dfd5fb54096f59c5e17</sha1>
     <cve>CVE-2021-43045</cve>


### PR DESCRIPTION
# Motivation

Avro 1.11.3 contains critical 9.3/10 level RCE vulnerability in Avro Java SDK <1.11.4, [CVE-2024-47561](https://github.com/advisories/GHSA-r7pg-v2c8-mfg3)>